### PR TITLE
Stop audio visualizer from appearing in screen record mode.

### DIFF
--- a/app/src/main/java/com/bnyro/recorder/ui/components/RecorderPreview.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/components/RecorderPreview.kt
@@ -12,19 +12,25 @@ import com.bnyro.recorder.ui.models.RecorderModel
 @Composable
 fun RecorderPreview(recordScreenMode: Boolean) {
     val recorderModel: RecorderModel = viewModel()
-    Crossfade(
-        modifier = Modifier.fillMaxSize(),
-        targetState = recorderModel.recordedAmplitudes
-    ) {
-        when (it.isEmpty()) {
-            true -> BlobIconBox(
-                icon = if (recordScreenMode) R.drawable.ic_screen_record else R.drawable.ic_mic
-            )
+    if (recordScreenMode) {
+        BlobIconBox(
+            icon = R.drawable.ic_screen_record
+        )
+    } else {
+        Crossfade(
+            modifier = Modifier.fillMaxSize(),
+            targetState = recorderModel.recordedAmplitudes
+        ) {
+            when (it.isEmpty()) {
+                true -> BlobIconBox(
+                    icon = R.drawable.ic_mic
+                )
 
-            false -> AudioVisualizer(
-                modifier = Modifier
-                    .fillMaxSize()
-            )
+                false -> AudioVisualizer(
+                    modifier = Modifier
+                        .fillMaxSize()
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Stop this from happening

<img src="https://github.com/you-apps/RecordYou/assets/64766434/e2bbd160-b887-44a6-8d5d-55b33e9bc5e0" width ="30%">
