### PR TITLE
Improve German translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -62,6 +62,6 @@
     <string name="delete_all">Alle löschen</string>
     <string name="screen_recorder_annotation">Bildschirmaufnahmeanmerkungen</string>
     <string name="screen_recorder_annotation_desc">Zeige Anmerkungenwerkzeug während Bildschirmaufnahme</string>
-    <string name="audio_visualizer_timestamps">Audiovisulisierungs-Zeitstempel</string>
+    <string name="audio_visualizer_timestamps">Audiovisualisierungs-Zeitstempel</string>
     <string name="audio_visualizer_timestamps_description">Zeige Zeitstempel in der Audiovisualisierungs-Zeitleiste.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -61,5 +61,5 @@
     <string name="translation">Übersetzung</string>
     <string name="delete_all">Alle löschen</string>
     <string name="screen_recorder_annotation">Bildschirmaufnahmeanmerkungen</string>
-    <string name="screen_recorder_annotation_desc">Zeige Anmerkungenwerkzeug während Bildschirmaufnahmr</string>
+    <string name="screen_recorder_annotation_desc">Zeige Anmerkungenwerkzeug während Bildschirmaufnahme</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -62,4 +62,6 @@
     <string name="delete_all">Alle löschen</string>
     <string name="screen_recorder_annotation">Bildschirmaufnahmeanmerkungen</string>
     <string name="screen_recorder_annotation_desc">Zeige Anmerkungenwerkzeug während Bildschirmaufnahme</string>
+    <string name="audio_visualizer_timestamps">Audiovisulisierungs-Zeitstempel</string>
+    <string name="audio_visualizer_timestamps_description">Zeige Zeitstempel in der Audiovisualisierungs-Zeitleiste.</string>
 </resources>


### PR DESCRIPTION
The audio visualizer timestamp resource text is translated to German in this PR as well as a little type fix, that is also made in this PR.