### PR TITLE
Android 14 related fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,8 @@
 
         <service
             android:name=".services.LosslessRecorderService"
-            android:exported="false" android:foregroundServiceType="microphone" />
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
 
         <receiver
             android:name=".receivers.FinishedNotificationReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -46,11 +47,11 @@
 
         <service
             android:name=".services.AudioRecorderService"
-            android:exported="false" />
+            android:exported="false" android:foregroundServiceType="microphone" />
 
         <service
             android:name=".services.LosslessRecorderService"
-            android:exported="false" />
+            android:exported="false" android:foregroundServiceType="microphone" />
 
         <receiver
             android:name=".receivers.FinishedNotificationReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,8 @@
 
         <service
             android:name=".services.AudioRecorderService"
-            android:exported="false" android:foregroundServiceType="microphone" />
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
 
         <service
             android:name=".services.LosslessRecorderService"

--- a/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
@@ -1,6 +1,8 @@
 package com.bnyro.recorder.services
 
+import android.content.pm.ServiceInfo
 import android.media.MediaRecorder
+import android.os.Build
 import android.widget.Toast
 import com.bnyro.recorder.App
 import com.bnyro.recorder.R
@@ -13,6 +15,13 @@ import com.bnyro.recorder.util.Preferences
 class AudioRecorderService : RecorderService() {
     override val notificationTitle: String
         get() = getString(R.string.recording_audio)
+
+    override val fgServiceType: Int?
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+        } else {
+            null
+        }
 
     override fun start() {
         val audioFormat = AudioFormat.getCurrent()

--- a/app/src/main/java/com/bnyro/recorder/services/LosslessRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/LosslessRecorderService.kt
@@ -1,6 +1,7 @@
 package com.bnyro.recorder.services
 
 import android.annotation.SuppressLint
+import android.content.pm.ServiceInfo
 import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
@@ -21,6 +22,13 @@ import kotlin.experimental.or
 class LosslessRecorderService : RecorderService() {
     override val notificationTitle: String
         get() = getString(R.string.recording_audio)
+
+    override val fgServiceType: Int?
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+        } else {
+            null
+        }
 
     private var audioRecorder: AudioRecord? = null
     private var recorderThread: Thread? = null

--- a/app/src/main/java/com/bnyro/recorder/services/RecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/RecorderService.kt
@@ -17,6 +17,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
 import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
@@ -91,28 +92,18 @@ abstract class RecorderService : LifecycleService() {
         runCatching {
             unregisterReceiver(bluetoothReceiver)
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            registerReceiver(
-                bluetoothReceiver,
-                IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED),
-                RECEIVER_EXPORTED
-            )
-        } else {
-            registerReceiver(
-                bluetoothReceiver,
-                IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED)
-            )
-        }
+        ContextCompat.registerReceiver(
+            this,
+            bluetoothReceiver,
+            IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED),
+            RECEIVER_EXPORTED
+        )
         audioManager.startBluetoothSco()
 
         runCatching {
             unregisterReceiver(recorderReceiver)
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            registerReceiver(recorderReceiver, IntentFilter(RECORDER_INTENT_ACTION), RECEIVER_EXPORTED)
-        } else {
-            registerReceiver(recorderReceiver, IntentFilter(RECORDER_INTENT_ACTION))
-        }
+        ContextCompat.registerReceiver(this, recorderReceiver, IntentFilter(RECORDER_INTENT_ACTION), RECEIVER_EXPORTED)
 
         super.onCreate()
     }

--- a/app/src/main/java/com/bnyro/recorder/services/RecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/RecorderService.kt
@@ -91,16 +91,28 @@ abstract class RecorderService : LifecycleService() {
         runCatching {
             unregisterReceiver(bluetoothReceiver)
         }
-        registerReceiver(
-            bluetoothReceiver,
-            IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED)
-        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            registerReceiver(
+                bluetoothReceiver,
+                IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED),
+                RECEIVER_EXPORTED
+            )
+        } else {
+            registerReceiver(
+                bluetoothReceiver,
+                IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED)
+            )
+        }
         audioManager.startBluetoothSco()
 
         runCatching {
             unregisterReceiver(recorderReceiver)
         }
-        registerReceiver(recorderReceiver, IntentFilter(RECORDER_INTENT_ACTION))
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            registerReceiver(recorderReceiver, IntentFilter(RECORDER_INTENT_ACTION), RECEIVER_EXPORTED)
+        } else {
+            registerReceiver(recorderReceiver, IntentFilter(RECORDER_INTENT_ACTION))
+        }
 
         super.onCreate()
     }

--- a/app/src/main/java/com/bnyro/recorder/services/ScreenRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/ScreenRecorderService.kt
@@ -56,6 +56,13 @@ class ScreenRecorderService : RecorderService() {
             Log.e("Media Projection Error", e.toString())
             onDestroy()
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            mediaProjection!!.registerCallback(object : MediaProjection.Callback() {
+                override fun onStop() {
+                    onDestroy()
+                }
+            }, null)
+        }
     }
 
     override fun start() {


### PR DESCRIPTION
* Use FOREGROUND_SERVICE_MICROPHONE permission
* Similarly how ScreenRecorderService overrides fgServiceType property to FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION make both AudioRecorderService and LosslessRecorderService inline with this on android 14 and newer by overriding its fgServiceType to FOREGROUND_SERVICE_TYPE_MICROPHONE.
* RecorderService: When registering receivers use the RECEIVER_EXPORTED flag to avoid security exceptions on Android 14
* ScreenRecorderService: added onStop callback to the MediaProjection. It may possibly fix #258.