### PR TITLE
Allow high quality opus recording

### DIFF
--- a/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
@@ -26,10 +26,11 @@ class AudioRecorderService : RecorderService() {
             }
             Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf { it > 0 }
                 ?.let {
-                    if (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS || listOf(8000, 12000, 16000, 24000, 48000).contains(it)) {
-                        setAudioSamplingRate(it)
+                    val sampleratePreference = it
+                    if (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS || listOf(8000, 12000, 16000, 24000, 48000).contains(sampleratePreference)) {
+                        setAudioSamplingRate(sampleratePreference)
                     }
-                    setAudioEncodingBitRate(it * 32 * 2)
+                    setAudioEncodingBitRate(sampleratePreference * 32 * 2)
                 }
 
             Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {

--- a/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
@@ -25,15 +25,14 @@ class AudioRecorderService : RecorderService() {
             setAudioSource(audioSource)
 
             val sampleRatePref = Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf { it > 0 }
-            if (sampleRatePref != null) {
-                if (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS || opusSampleRates.contains(sampleRatePref)) {
-                    setAudioSamplingRate(sampleRatePref)
-                }
-                setAudioEncodingBitRate(sampleRatePref * 32 * 2)
+            val audioBitrate = Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }
+            if (sampleRatePref != null && (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS || sampleRatePref in opusSampleRates)) {
+                setAudioSamplingRate(sampleRatePref)
             }
-
-            Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
-                setAudioEncodingBitRate(it)
+            if (audioBitrate != null) {
+                setAudioEncodingBitRate(audioBitrate)
+            } else if (sampleRatePref != null) {
+                setAudioEncodingBitRate(sampleRatePref * 32 * 2)
             }
 
             Preferences.prefs.getInt(Preferences.audioChannelsKey, AudioChannels.MONO.value).let {

--- a/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
@@ -24,15 +24,16 @@ class AudioRecorderService : RecorderService() {
             ).let {
                 setAudioSource(it)
             }
-            if (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS) {
-                Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf { it > 0 }
-                    ?.let {
+            Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf { it > 0 }
+                ?.let {
+                    if (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS || listOf(8000, 12000, 16000, 24000, 48000).contains(it)) {
                         setAudioSamplingRate(it)
-                        setAudioEncodingBitRate(it * 32 * 2)
                     }
-                Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
-                    setAudioEncodingBitRate(it)
+                    setAudioEncodingBitRate(it * 32 * 2)
                 }
+
+            Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
+                setAudioEncodingBitRate(it)
             }
 
             Preferences.prefs.getInt(Preferences.audioChannelsKey, AudioChannels.MONO.value).let {

--- a/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
+++ b/app/src/main/java/com/bnyro/recorder/services/AudioRecorderService.kt
@@ -18,20 +18,19 @@ class AudioRecorderService : RecorderService() {
         val audioFormat = AudioFormat.getCurrent()
 
         recorder = PlayerHelper.newRecorder(this).apply {
-            Preferences.prefs.getInt(
+            val audioSource = Preferences.prefs.getInt(
                 Preferences.audioDeviceSourceKey,
                 AudioDeviceSource.DEFAULT.value
-            ).let {
-                setAudioSource(it)
-            }
-            Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf { it > 0 }
-                ?.let {
-                    val sampleratePreference = it
-                    if (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS || listOf(8000, 12000, 16000, 24000, 48000).contains(sampleratePreference)) {
-                        setAudioSamplingRate(sampleratePreference)
-                    }
-                    setAudioEncodingBitRate(sampleratePreference * 32 * 2)
+            )
+            setAudioSource(audioSource)
+
+            val sampleRatePref = Preferences.prefs.getInt(Preferences.audioSampleRateKey, -1).takeIf { it > 0 }
+            if (sampleRatePref != null) {
+                if (audioFormat.codec != MediaRecorder.AudioEncoder.OPUS || opusSampleRates.contains(sampleRatePref)) {
+                    setAudioSamplingRate(sampleRatePref)
                 }
+                setAudioEncodingBitRate(sampleRatePref * 32 * 2)
+            }
 
             Preferences.prefs.getInt(Preferences.audioBitrateKey, -1).takeIf { it > 0 }?.let {
                 setAudioEncodingBitRate(it)
@@ -71,4 +70,8 @@ class AudioRecorderService : RecorderService() {
     }
 
     override fun getCurrentAmplitude() = recorder?.maxAmplitude
+
+    companion object {
+        private val opusSampleRates =  listOf(8000, 12000, 16000, 24000, 48000)
+    }
 }


### PR DESCRIPTION
Opus codec supports low latency and high quality audio recording. I think we should make more reasonable defaults and allow more fine grained control for people who know what they are doing. Another stab at fixing #193.
Since #235 as an addition to disabling sample rate control setting up the bitrate is no longer working for opus file recordings.
    These sample rates are natively supported by the opus encoder with no resampling involved: 8, 12, 16, 24, or 48 kHz. See this FAQ answer and a few follow up answers https://wiki.xiph.org/OpusFAQ#What_is_Opus_Custom?
When not specifying the sample rate at all resulting files have some kind of default sample rate that severely degrades audio quality. When inspecting files with ffmpeg the sample rate is always displayed as 48000. I have verified that setting the sample rate it increases audio quality though. Changes based off of this:
* Again respect bitrate setting when recording into opus. Bitrate of 32000, 40000 or 48000 sound very goot for casual recordings sampled at 48000 Hz.
* Allow setting sample rate for opus encoding when specifying one of the supported values.