### PR TITLE
feat: support for recording internal audio in rooted devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission
+        android:name="android.permission.CAPTURE_AUDIO_OUTPUT"
+        tools:ignore="ProtectedPermissions" />
+
 
     <!-- Opt out for network permissions that are optional for the ExoPlayer -->
     <uses-permission

--- a/app/src/main/java/com/bnyro/recorder/enums/AudioDeviceSource.kt
+++ b/app/src/main/java/com/bnyro/recorder/enums/AudioDeviceSource.kt
@@ -6,7 +6,8 @@ enum class AudioDeviceSource(val value: Int) {
     DEFAULT(MediaRecorder.AudioSource.DEFAULT),
     MIC(MediaRecorder.AudioSource.MIC),
     CAMCORDER(MediaRecorder.AudioSource.CAMCORDER),
-    UNPROCESSED(MediaRecorder.AudioSource.UNPROCESSED);
+    UNPROCESSED(MediaRecorder.AudioSource.UNPROCESSED),
+    REMOTE_SUBMIX(MediaRecorder.AudioSource.REMOTE_SUBMIX);
 
     companion object {
         fun fromInt(value: Int) = AudioDeviceSource.values().first { it.value == value }

--- a/app/src/main/java/com/bnyro/recorder/ui/models/RecorderModel.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/models/RecorderModel.kt
@@ -10,7 +10,6 @@ import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.result.ActivityResult
 import androidx.annotation.RequiresApi
@@ -90,7 +89,7 @@ class RecorderModel : ViewModel() {
         if (!PermissionHelper.checkPermissions(context, audioPermission.toTypedArray())) {
             Toast.makeText(
                 context,
-                context.getString(R.string.no_enough_permissions), Toast.LENGTH_SHORT
+                context.getString(R.string.no_sufficient_permissions), Toast.LENGTH_SHORT
             )
                 .show()
             return
@@ -193,15 +192,13 @@ class RecorderModel : ViewModel() {
         if (requiredPermissions.isEmpty()) return true
 
         val granted = PermissionHelper.checkPermissions(context, requiredPermissions.toTypedArray())
-        if (granted) {
-            return true
-        } else {
+        if (!granted) {
             Toast.makeText(
                 context,
-                context.getString(R.string.no_enough_permissions), Toast.LENGTH_SHORT
+                context.getString(R.string.no_sufficient_permissions), Toast.LENGTH_SHORT
             )
                 .show()
-            return false
         }
+        return granted
     }
 }

--- a/app/src/main/java/com/bnyro/recorder/ui/models/RecorderModel.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/models/RecorderModel.kt
@@ -12,6 +12,7 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.provider.Settings
+import android.widget.Toast
 import androidx.activity.result.ActivityResult
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
@@ -20,7 +21,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
+import com.bnyro.recorder.R
 import com.bnyro.recorder.canvas_overlay.CanvasOverlay
+import com.bnyro.recorder.enums.AudioDeviceSource
 import com.bnyro.recorder.enums.AudioSource
 import com.bnyro.recorder.enums.RecorderState
 import com.bnyro.recorder.services.AudioRecorderService
@@ -31,7 +34,6 @@ import com.bnyro.recorder.util.PermissionHelper
 import com.bnyro.recorder.util.Preferences
 
 class RecorderModel : ViewModel() {
-    private val audioPermission = arrayOf(Manifest.permission.RECORD_AUDIO)
     private val supportsOverlay = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
 
     var recorderState by mutableStateOf(RecorderState.IDLE)
@@ -73,7 +75,26 @@ class RecorderModel : ViewModel() {
 
     @SuppressLint("NewApi")
     fun startAudioRecorder(context: Context) {
-        if (!PermissionHelper.checkPermissions(context, audioPermission)) return
+        val audioPermission = mutableListOf(Manifest.permission.RECORD_AUDIO)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            audioPermission.add(Manifest.permission.POST_NOTIFICATIONS)
+        }
+        val internalAudio = Preferences.prefs.getInt(
+            Preferences.audioDeviceSourceKey,
+            0
+        ) == AudioDeviceSource.REMOTE_SUBMIX.value
+        if (internalAudio) {
+            audioPermission.add(Manifest.permission.CAPTURE_AUDIO_OUTPUT)
+        }
+
+        if (!PermissionHelper.checkPermissions(context, audioPermission.toTypedArray())) {
+            Toast.makeText(
+                context,
+                context.getString(R.string.no_enough_permissions), Toast.LENGTH_SHORT
+            )
+                .show()
+            return
+        }
 
         val serviceIntent =
             if (Preferences.prefs.getBoolean(Preferences.losslessRecorderKey, false)) {
@@ -171,12 +192,29 @@ class RecorderModel : ViewModel() {
             Preferences.prefs.getInt(Preferences.audioSourceKey, 0) == AudioSource.MICROPHONE.value
 
         if (recordAudio) requiredPermissions.add(Manifest.permission.RECORD_AUDIO)
+
+        val internalAudio = Preferences.prefs.getInt(
+            Preferences.audioDeviceSourceKey,
+            0
+        ) == AudioDeviceSource.REMOTE_SUBMIX.value
+        if (internalAudio) requiredPermissions.add(Manifest.permission.CAPTURE_AUDIO_OUTPUT)
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requiredPermissions.add(Manifest.permission.POST_NOTIFICATIONS)
         }
 
         if (requiredPermissions.isEmpty()) return true
 
-        return PermissionHelper.checkPermissions(context, requiredPermissions.toTypedArray())
+        val granted = PermissionHelper.checkPermissions(context, requiredPermissions.toTypedArray())
+        if (granted) {
+            return true
+        } else {
+            Toast.makeText(
+                context,
+                context.getString(R.string.no_enough_permissions), Toast.LENGTH_SHORT
+            )
+                .show()
+            return false
+        }
     }
 }

--- a/app/src/main/java/com/bnyro/recorder/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/bnyro/recorder/ui/screens/SettingsScreen.kt
@@ -173,7 +173,8 @@ fun SettingsScreen() {
                     R.string.default_audio,
                     R.string.microphone,
                     R.string.camcorder,
-                    R.string.unprocessed
+                    R.string.unprocessed,
+                    R.string.internal_audio
                 ).map {
                     stringResource(it)
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,6 @@
     <string name="cant_access_selected_folder">Can\'t access selected folder!</string>
     <string name="draw_mode">Draw Mode</string>
     <string name="erase_mode">Erase Mode</string>
+    <string name="internal_audio">Internal Audio (Root)</string>
+    <string name="no_enough_permissions">No enough permissions to start recording</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,5 +86,5 @@
     <string name="draw_mode">Draw Mode</string>
     <string name="erase_mode">Erase Mode</string>
     <string name="internal_audio">Internal Audio (Root)</string>
-    <string name="no_enough_permissions">No enough permissions to start recording</string>
+    <string name="no_sufficient_permissions">No sufficient permissions to start recording</string>
 </resources>


### PR DESCRIPTION
closes #281

### Demo recording


https://github.com/you-apps/RecordYou/assets/64766434/3b40bb55-9be7-4683-a1e1-0c9fa9dc0289

<hr>

<details>
  <summary> Guide for Root users</summary>

For this to work the app needs the `android.permission.CAPTURE_AUDIO_OUTPUT` permission. This permission is a privileged permission. so the app needs to be installed as a privileged app.

### How to manually grant the permission

1. Install the app as a normal app
2. use `adb root` or any other method to move the app's apk from `/data/app/<app folder>` to `/system/priv-app/RecordYou/RecordYou.apk`
3. create a new file `priv-app-permission-recordyou.xml` (name doesn't matter) with the following content:
```xml
<permissions>
	<privapp-permissions package="com.bnyro.recorder">
		<permission name="android.permission.CAPTURE_AUDIO_OUTPUT" />
	</privapp-permissions>
</permissions>
```
4. reboot the phone and use the feature
</details>



